### PR TITLE
Fix service worker ESLint error

### DIFF
--- a/src/registerServiceWorker.js
+++ b/src/registerServiceWorker.js
@@ -1,4 +1,3 @@
-/* global process */
 // In production, we register a service worker to serve assets from local cache.
 
 // This lets the app load faster on subsequent visits in production, and gives


### PR DESCRIPTION
## Summary
- remove redundant `/* global process */` from `registerServiceWorker.js` to fix build

## Testing
- `npm run build`
- `CI=true npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_684194f27db0832e96f1f14f0584a5df